### PR TITLE
feat: JWT

### DIFF
--- a/src/main/java/com/example/projectbluehair/common/security/WebSecurityConfig.java
+++ b/src/main/java/com/example/projectbluehair/common/security/WebSecurityConfig.java
@@ -1,5 +1,9 @@
 package com.example.projectbluehair.common.security;
 
+import com.example.projectbluehair.common.security.exception.CustomAccessDeniedHandler;
+import com.example.projectbluehair.common.security.exception.CustomAuthenticationEntryPoint;
+import com.example.projectbluehair.common.security.exception.CustomSecurityErrorCode;
+import com.example.projectbluehair.common.security.exception.CustomSecurityException;
 import com.example.projectbluehair.common.security.jwt.JwtAuthFilter;
 import com.example.projectbluehair.common.security.jwt.JwtUtil;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +16,7 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -20,6 +25,8 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 public class WebSecurityConfig {
     private final JwtUtil jwtUtil;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
     @Bean // 비밀번호 암호화
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
@@ -53,6 +60,11 @@ public class WebSecurityConfig {
                 anyRequest().authenticated().
                 // JWT Filter 등록
                 and().addFilterBefore(new JwtAuthFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
+
+        // 401 Error, 인증 실패
+        http.exceptionHandling().authenticationEntryPoint(customAuthenticationEntryPoint);
+        // 403 Error, 권한 오류
+        http.exceptionHandling().accessDeniedHandler(customAccessDeniedHandler);
 
         return http.build();
     }

--- a/src/main/java/com/example/projectbluehair/common/security/exception/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/example/projectbluehair/common/security/exception/CustomAccessDeniedHandler.java
@@ -1,0 +1,36 @@
+package com.example.projectbluehair.common.security.exception;
+
+import com.example.projectbluehair.common.response.ResponseDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.OutputStream;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+    ResponseDto responseDto = new ResponseDto(HttpStatus.UNAUTHORIZED, "토큰 권한 오류", null);
+
+    @Override
+    public void handle(HttpServletRequest request,
+                       HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException{
+
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+
+        try (OutputStream os = response.getOutputStream()) {
+            ObjectMapper objectMapper = new ObjectMapper();
+            objectMapper.writeValue(os, responseDto);
+            os.flush();
+        }
+    }
+}

--- a/src/main/java/com/example/projectbluehair/common/security/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/projectbluehair/common/security/exception/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,36 @@
+package com.example.projectbluehair.common.security.exception;
+
+import com.example.projectbluehair.common.response.ResponseDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.OutputStream;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    ResponseDto responseDto = new ResponseDto(HttpStatus.UNAUTHORIZED, "토큰 권한 오류", null);
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authenticationException) throws IOException {
+
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+
+        try (OutputStream os = response.getOutputStream()) {
+            ObjectMapper objectMapper = new ObjectMapper();
+            objectMapper.writeValue(os, responseDto);
+            os.flush();
+        }
+    }
+}

--- a/src/main/java/com/example/projectbluehair/common/security/jwt/JwtUtil.java
+++ b/src/main/java/com/example/projectbluehair/common/security/jwt/JwtUtil.java
@@ -35,7 +35,7 @@ public class JwtUtil {
     // 토큰 생성 시 앞에 붙는 식별자
     private static final String BEARER_PREFIX = "Bearer ";
     // 토큰 만료 시간
-    private static final long TOKEN_TIME = 60 * 60 * 1000L;
+    private static final long TOKEN_TIME = 60 * 1000L;
 
     // JWT SecretKey 불러오기
     @Value("${jwt.secret.key}")


### PR DESCRIPTION
JWT Exception Handling 오류 처리

- 기존 방식은 Controller 계층에서 에러 처리를 하는 방식이었음.
- JWT 관련 Exception은 Filter에서 발생하기 때문에, Controller 계층에서 처리가 불가능함.
- 해결은 다음과 같음.

1. AccessDeniedHandler, AuthenticationEntryPoint를 상속받은 클래스 선언
2. @Override를 통해 Method들을 재정의하고, ResponseDto 객체에 담아 반환하도록 함.
 - SuccessResponse를 사용하려 했으나, Initialize가 되어있지 않다는 에러와 함께 컴파일이 불가능 했음. DI/IoC는 정상적으로 설정되어 있었음. (Component, RequiredArgsConstructor 등)
 - 원인은 확인 필요